### PR TITLE
Exclude React dependency from the output bundle.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,5 +16,8 @@ module.exports = {
           }
         }
       ]
+    },
+	externals: {
+        react: 'react',
     }
   };


### PR DESCRIPTION
Actually this projet will only work for a React Projet. I assume there is no need to bundle ReactJS in the generated file.
=> This will reduce the bundle size from 26ko to about 16Ko.