### PR TITLE
Added type=button to prevent form Auto-Submit

### DIFF
--- a/src/buttons/SocialLoginButton.js
+++ b/src/buttons/SocialLoginButton.js
@@ -66,6 +66,7 @@ export default class SocialLoginButton extends Component {
 
     return (
       <button
+        type="button"
         style={buttonStyles}
         onClick={this.handleClick}
         onMouseEnter={this.handleMouseEnter}


### PR DESCRIPTION
When the Social button is used within a form, not supplying type prop defaults to type=submit in most browsers except Internet Explorer. This causes unintended auto-submission of the form.