### PR TITLE
fix: Add size property to SpecificSocialLoginButtonProps interface

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,6 +21,9 @@ interface SpecificSocialLoginButtonProps {
   /** The size of icon e.g. "26px". */
   iconSize?: string;
 
+  /** The size of box e.g. "150px". */
+  size?: string;
+
   /** Color of the icon - default is #FFFFFF */
   iconColor?: string;
 


### PR DESCRIPTION
This fixes size property unavailability in components, and matches the documentation in the README file.

BREAKING CHANGE
Before this fix size property wasn't available in the components properties, and the implementation wasn't match the library documentation